### PR TITLE
disabling cache on select requests

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -36,6 +36,14 @@ ${indexHtml[1]}`;
   };
 }());
 
+function noCache(req, res, next) {
+  res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.setHeader('Pragma', 'no-cache');
+  res.setHeader('Expires', '0');
+
+  next();
+}
+
 function writeError(res, message) {
   // hacky, but whatevs
   noCache(null, res, function () {});
@@ -52,22 +60,6 @@ function getRootUrl(req) {
       `localhost:${PORT}`;
 
   return `${proto}://${host}`;
-}
-
-function noCacheHeaders(headers) {
-  return Object.assign({
-    'Cache-Control': 'no-cache, no-store, must-revalidate',
-    'Pragma': 'no-cache',
-    'Expires': 0
-  }, headers);
-}
-
-function noCache(req, res, next) {
-  res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
-  res.setHeader('Pragma', 'no-cache');
-  res.setHeader('Expires', '0');
-
-  next();
 }
 
 app.use(cookies.connect());

--- a/server/server.js
+++ b/server/server.js
@@ -85,15 +85,15 @@ app.get('/', noCache, function (req, res) {
   res.end(renderIndex(token || TOKEN));
 });
 
-app.get('/instagram/login', function (req, res) {
+app.get('/instagram/login', noCache, function (req, res) {
   var code = req.query.code;
 
   if (!code) {
     console.log('no login code received', req.query);
 
-    res.writeHead(302, noCacheHeaders({
+    res.writeHead(302, {
       location: getRootUrl(req) + '?error=true'
-    }));
+    });
     res.end();
     return;
   }
@@ -129,9 +129,9 @@ app.get('/instagram/login', function (req, res) {
       httpOnly: true,
       overwrite: true
     });
-    res.writeHead(302, noCacheHeaders({
+    res.writeHead(302, {
       location: getRootUrl(req)
-    }));
+    });
     res.end('');
   });
 });

--- a/server/server.js
+++ b/server/server.js
@@ -37,7 +37,10 @@ ${indexHtml[1]}`;
 }());
 
 function writeError(res, message) {
-  res.writeHead(580, noCacheHeaders({}));
+  // hacky, but whatevs
+  noCache(null, res, function () {});
+
+  res.writeHead(580);
   res.end(message.toString());
 }
 

--- a/server/server.js
+++ b/server/server.js
@@ -51,6 +51,14 @@ function getRootUrl(req) {
   return `${proto}://${host}`;
 }
 
+function noCacheHeaders(headers) {
+  return Object.assign({
+    'Cache-Control': 'no-cache, no-store, must-revalidate',
+    'Pragma': 'no-cache',
+    'Expires': 0
+  }, headers);
+}
+
 app.use(cookies.connect());
 
 app.get('/', function (req, res) {
@@ -60,12 +68,9 @@ app.get('/', function (req, res) {
     token = req.cookies.get('igtoken') || token;
   } catch (e) { }
 
-  res.writeHead(200, {
-    'Cache-Control': 'no-cache, no-store, must-revalidate',
-    'Pragma': 'no-cache',
-    'Expires': 0,
+  res.writeHead(200, noCacheHeaders({
     'content-type': 'text/html'
-  });
+  }));
   res.end(renderIndex(token || TOKEN));
 });
 

--- a/server/server.js
+++ b/server/server.js
@@ -37,7 +37,7 @@ ${indexHtml[1]}`;
 }());
 
 function writeError(res, message) {
-  res.writeHead(580);
+  res.writeHead(580, noCacheHeaders({}));
   res.end(message.toString());
 }
 

--- a/server/server.js
+++ b/server/server.js
@@ -59,18 +59,26 @@ function noCacheHeaders(headers) {
   }, headers);
 }
 
+function noCache(req, res, next) {
+  res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.setHeader('Pragma', 'no-cache');
+  res.setHeader('Expires', '0');
+
+  next();
+}
+
 app.use(cookies.connect());
 
-app.get('/', function (req, res) {
+app.get('/', noCache, function (req, res) {
   var token = '';
 
   try {
     token = req.cookies.get('igtoken') || token;
   } catch (e) { }
 
-  res.writeHead(200, noCacheHeaders({
+  res.writeHead(200, {
     'content-type': 'text/html'
-  }));
+  });
   res.end(renderIndex(token || TOKEN));
 });
 

--- a/server/server.js
+++ b/server/server.js
@@ -60,7 +60,12 @@ app.get('/', function (req, res) {
     token = req.cookies.get('igtoken') || token;
   } catch (e) { }
 
-  res.writeHead(200, { 'content-type': 'text/html' });
+  res.writeHead(200, {
+    'Cache-Control': 'no-cache, no-store, must-revalidate',
+    'Pragma': 'no-cache',
+    'Expires': 0,
+    'content-type': 'text/html'
+  });
   res.end(renderIndex(token || TOKEN));
 });
 

--- a/server/server.js
+++ b/server/server.js
@@ -80,9 +80,9 @@ app.get('/instagram/login', function (req, res) {
   if (!code) {
     console.log('no login code received', req.query);
 
-    res.writeHead(302, {
+    res.writeHead(302, noCacheHeaders({
       location: getRootUrl(req) + '?error=true'
-    });
+    }));
     res.end();
     return;
   }
@@ -118,9 +118,9 @@ app.get('/instagram/login', function (req, res) {
       httpOnly: true,
       overwrite: true
     });
-    res.writeHead(302, {
+    res.writeHead(302, noCacheHeaders({
       location: getRootUrl(req)
-    });
+    }));
     res.end('');
   });
 });


### PR DESCRIPTION
#61 

`/` - responses are custom-generated every time
`/instagram/login` - obviously... don't cache logins